### PR TITLE
Fixes #3 and #15

### DIFF
--- a/service/put_command.go
+++ b/service/put_command.go
@@ -51,6 +51,11 @@ func (c *PutCommand) Handle(cmd *slack.SlashCommand, s *Service, w http.Response
 	w.Header().Set("Content-Type", "application/json")
 	w.Write(b)
 
+	if resp.Ok {
+		// Don't post admin if already in queue.
+		return
+	}
+
 	str := fmt.Sprintf("%s added to queue in position %d", userToLink(resp.User), resp.Pos+1)
 	cerr := c.perms.SendAdminMessage(str)
 	if cerr != nil {


### PR DESCRIPTION
When a user is removed, the list response that generated the dequeue message is refreshed.

This also has the effect of a user attempting to moderate from a stale list gets an updated list when they try to moderate.

Related: #11 