### PR TITLE
Fixes #10: Adds queue reordering actions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 secrets
 slack-queue
 sq-linux-amd64
+tmp/

--- a/service/action.go
+++ b/service/action.go
@@ -7,8 +7,11 @@ import (
 )
 
 const (
+	// TODO make flags or make a config file.
 	takeActionName   = "take"
 	removeActionName = "remove"
+	upActionName     = "up"
+	downActionName   = "down"
 )
 
 // TODO(#20): There is a ton of duplicate code between the dequeue action and command and
@@ -18,6 +21,8 @@ func DefaultActions(api *slack.Client, perms AdminInterface) (actions map[string
 	actions = make(map[string]Action)
 	actions[removeActionName] = &RemoveAction{api, perms}
 	actions[takeActionName] = &TakeAction{api, perms}
+	actions[upActionName] = &MoveAction{api, perms}
+	actions[downActionName] = &MoveAction{api, perms}
 	return
 }
 
@@ -35,6 +40,11 @@ type RemoveAction struct {
 }
 
 type TakeAction struct {
+	api   *slack.Client
+	perms AdminInterface
+}
+
+type MoveAction struct {
 	api   *slack.Client
 	perms AdminInterface
 }

--- a/service/list_command.go
+++ b/service/list_command.go
@@ -24,9 +24,18 @@ func listAsBlock(resp *ListResponse) (blocks []slack.Block) {
 		userblock := slack.NewTextBlockObject("mrkdwn", userinfo, false, false)
 		iconblock := slack.NewImageBlockElement(user.Profile.Image24, user.Name)
 		blocks[i*3+1] = slack.NewSectionBlock(userblock, nil, slack.NewAccessory(iconblock))
-		remove := slack.NewButtonBlockElement("remove", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", "Remove", false, false))
-		take := slack.NewButtonBlockElement("take", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", "Dequeue", false, false))
-		blocks[i*3+2] = slack.NewActionBlock(fmt.Sprintf("actions_%v", user.ID), remove, take)
+
+		buttons := make([]slack.BlockElement, 2, 4)
+
+		buttons[0] = slack.NewButtonBlockElement("remove", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", "Remove", false, false))
+		buttons[1] = slack.NewButtonBlockElement("take", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", "Dequeue", false, false))
+		if i != 0 {
+			buttons = append(buttons, slack.NewButtonBlockElement("up", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", ":arrow_up_small:", true, false)))
+		}
+		if i != len(resp.Users)-1 {
+			buttons = append(buttons, slack.NewButtonBlockElement("down", GenerateActionValue(i, resp.Token), slack.NewTextBlockObject("plain_text", ":arrow_down_small:", true, false)))
+		}
+		blocks[i*3+2] = slack.NewActionBlock(fmt.Sprintf("actions_%v", user.ID), buttons...)
 	}
 
 	return

--- a/service/move_action.go
+++ b/service/move_action.go
@@ -1,0 +1,68 @@
+package service
+
+import (
+	"github.com/golang/glog"
+	"github.com/slack-go/slack"
+
+	"net/http"
+)
+
+func (a *MoveAction) Handle(action *slack.InteractionCallback, s *QueueService, w http.ResponseWriter) {
+	user := &action.User
+	ok, err := a.perms.IsAdmin(user)
+	if err != nil {
+		glog.Errorf("Error checking admin status of %v (%v): %v", user.ID, user.Name, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+	if !ok {
+		glog.Errorf("Permission denied to user %v (%v)", user.ID, user.Name)
+		w.WriteHeader(http.StatusUnauthorized)
+		return
+	}
+
+	var pos int
+	var token int64
+	var found bool
+	var actName string
+	// Move is a block action and should be in the actions for this callback.
+	for _, act := range action.ActionCallback.BlockActions {
+		actName = ParseAction(act.ActionID)
+		if actName == upActionName || actName == downActionName {
+			pos, token, err = ParseActionValue(act.Value)
+			found = true
+			if err != nil {
+				glog.Error("Error parsing action value %v: %v", act.Value, err)
+				w.WriteHeader(http.StatusInternalServerError)
+				return
+			}
+			break
+		}
+	}
+
+	if !found {
+		glog.Errorf("Take action not found for remove callback!")
+	}
+
+	glog.Infof("Moving position %d %s with token %d", pos, actName, token)
+
+	npos := pos - 1
+	if actName == downActionName {
+		npos = pos + 1
+	}
+
+	req := &MoveRequest{Pos: pos, NPos: npos, Token: token}
+	resp := &MoveResponse{}
+
+	err = s.Move(req, resp)
+	if err != nil {
+		glog.Errorf("Error moving %d from a request by %v (%v): %v", pos, action.User.ID, action.User.Name, err)
+		w.WriteHeader(http.StatusInternalServerError)
+		return
+	}
+
+	w.WriteHeader(http.StatusOK)
+
+	// Replace list with updated state.
+	updateListInUI(action, s, a.api)
+}

--- a/service/move_action.go
+++ b/service/move_action.go
@@ -61,6 +61,9 @@ func (a *MoveAction) Handle(action *slack.InteractionCallback, s *QueueService, 
 		return
 	}
 
+	// Don't care about ok status, since the UI will be refreshed with the current
+	// state anyway.
+
 	w.WriteHeader(http.StatusOK)
 
 	// Replace list with updated state.

--- a/service/queue_service.go
+++ b/service/queue_service.go
@@ -119,8 +119,7 @@ func (s *QueueService) Remove(req *RemoveRequest, resp *RemoveResponse) (err err
 	seq, e := s.q.Remove(req.Pos, req.Token)
 	resp.Token = seq
 	if e != nil {
-		ae, ok := e.(queue.VersionError)
-		if !ok {
+		if ae, ok := e.(queue.VersionError); !ok {
 			glog.Errorf("Unknown error on remove at %d with token %d: %+v:", req.Pos, req.Token, ae)
 			err = ae
 			return
@@ -128,6 +127,21 @@ func (s *QueueService) Remove(req *RemoveRequest, resp *RemoveResponse) (err err
 	}
 	glog.Infof("Remove at %d with token %d, error: %+v", req.Pos, req.Token, err)
 	resp.Err = e
+	return
+}
+
+func (s *QueueService) Move(req *MoveRequest, resp *MoveResponse) (err error) {
+	seq, e := s.q.Move(req.Pos, req.NPos, req.Token)
+	resp.Token = seq
+	if e != nil {
+		if ae, ok := e.(queue.VersionError); !ok {
+			glog.Errorf("Unknown error on move %d -> %d with token %d, error: %+v", req.Pos, req.NPos, req.Token, ae)
+			err = ae
+			return
+		}
+	}
+	glog.Info("Move %d -> %d, err: %+v", req.Pos, req.NPos, err)
+	resp.Ok = err == nil
 	return
 }
 

--- a/service/service_types.go
+++ b/service/service_types.go
@@ -50,3 +50,14 @@ type RemoveResponse struct {
 	Err   error
 	Token int64
 }
+
+type MoveRequest struct {
+	Pos   int
+	NPos  int
+	Token int64
+}
+
+type MoveResponse struct {
+	Ok    bool
+	Token int64
+}


### PR DESCRIPTION
Admins can now move users up and down in the queue.

This also closes #11  since this is the last moderation command.

But it does add some nasty code duplication that needs to be cleaned up (per #20). Actions/commands should be refactored to remove the permissions checking.